### PR TITLE
Install h264 decoder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt-get update \
-    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 --no-install-recommends \
+    && apt-get install -y google-chrome-stable x264 fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # To run Headful mode, you will need to have a display, which is not present in a server.
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -yq gconf-service libasound2 libatk1.0-0 l
 RUN mkdir -p /home/pptruser/Downloads
 WORKDIR /home/pptruser
 
-RUN npm install puppeteer@13.0.1 \
+RUN npm install puppeteer@10.1.0 \
     # Add user so we don't need --no-sandbox.
     # same layer as npm install to keep re-chowned files from using up several hundred MBs more space
     && groupadd -r pptruser && useradd -r -g pptruser -G audio,video pptruser \


### PR DESCRIPTION
TODO: this is not enough. One would most likely need a custom chromium instance with proprietary codecs if wanting do decode h264, to avoid this error: https://chromium.googlesource.com/chromium/src/+/ae236ff57f30a55fa2ef7669f1ff4556362c2e7c/third_party/blink/renderer/modules/webcodecs/video_decoder.cc#295